### PR TITLE
docs: repoint release permalinks and secret targets to gotchoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Signed Android release APKs are built by CI and published to permanent
 per-app download links — see [doc/releases/RELEASE-ANDROID.md](doc/releases/RELEASE-ANDROID.md)
 for the release process and repository secret setup.
 
-* [Voting APK (latest)](https://github.com/inspirions/votetorrent/releases/download/latest-voting/votetorrent-voting-latest.apk)
-* [Authority APK (latest)](https://github.com/inspirions/votetorrent/releases/download/latest-authority/votetorrent-authority-latest.apk)
+* [Voting APK (latest)](https://github.com/gotchoices/votetorrent/releases/download/latest-voting/votetorrent-voting-latest.apk)
+* [Authority APK (latest)](https://github.com/gotchoices/votetorrent/releases/download/latest-authority/votetorrent-authority-latest.apk)
 
 ## Contributing
 

--- a/doc/releases/RELEASE-ANDROID-UPSTREAM-SETUP.md
+++ b/doc/releases/RELEASE-ANDROID-UPSTREAM-SETUP.md
@@ -1,12 +1,21 @@
 # Setting up Android release CI on `gotchoices/votetorrent`
 
-Handoff for a repository **admin** of `gotchoices/votetorrent`. The same pipeline is
-already running and fully validated on the `inspirions/votetorrent` fork; this brings it
+Handoff for a maintainer of `gotchoices/votetorrent`. The same pipeline is already
+running and fully validated on the `inspirions/votetorrent` fork; this brings it
 upstream.
 
-Everything here needs admin rights — setting Actions secrets is admin-only, and no
-organization-level secrets are involved (they were unavailable on the account that built
-this, so the workflow deliberately depends only on repository-level secrets).
+**Most of this needs only repository write access, not admin.** Setting Actions secrets
+is gated on collaborator access, so `gh secret set` works at write level — verified
+2026-08-03 by setting and deleting a throwaway secret with a non-admin account. The
+Settings **UI** for secrets is admin-only, which is a different thing and is easy to
+mistake for the API being admin-only.
+
+Exactly one step here requires an admin: **§4**, confirming Actions is enabled and that
+no org policy caps the workflow token. `GET /actions/permissions` returns 403 below
+admin.
+
+No organization-level secrets are involved (they were unavailable on the account that
+built this, so the workflow deliberately depends only on repository-level secrets).
 
 Budget ~30 minutes, plus one ~20-minute CI build to verify.
 
@@ -25,24 +34,54 @@ uninstall and reinstall. Losing a key is unrecoverable.
 | **A. Reuse the existing keys** | You want upstream releases to be upgrade-compatible with anything already distributed from the fork, or the Authority key is already the project's real identity | Someone must transfer two keystore files + their passwords to you over a secure channel (see below) |
 | **B. Generate fresh keys** | Upstream is the canonical channel starting now, and prior fork builds were throwaway test releases | Clean separation, no key handoff — but any APK already installed from the fork cannot update to an upstream build |
 
-As of 2026-08-03 the only releases ever published from the fork are `voting-v0.1.0` and
-`authority-v0.1.0`, both first-ever CI test builds. That argues for **B** for the Voting
-app. The **Authority** key is a different matter: it was deliberately rotated on
-2026-07-30 and may already be the project's real signing identity — check with the
-maintainer before replacing it.
+> **Decided 2026-08-03: option A, reuse the fork's keys** — for both apps. Upstream
+> releases stay upgrade-compatible with the APKs already distributed from the fork, and
+> the Authority key, deliberately rotated on 2026-07-30, remains the project's signing
+> identity rather than being replaced weeks later.
 
-**If transferring keys (option A):** send the `.keystore` files and passwords through a
-password manager's secure-share, an encrypted archive over a separate channel, or in
-person. Never email, Slack, or paste them into an issue, PR, or chat. Never commit a
-keystore — `apps/*/android/.gitignore` blocks `*.keystore`, and that guard should not be
-overridden with `git add -f`.
+**Option A has a prerequisite that blocks everything downstream: the key handoff.**
+GitHub Actions secrets are write-only — once `VOTING_KEYSTORE_BASE64` is set on the fork,
+no API call, workflow, or repository admin can read it back, and a published APK carries
+only the public certificate, not the private key. There is no way to copy the fork's
+secrets to upstream through GitHub. The keystore *files* and their passwords must come
+from whoever holds them:
+
+| Credential | Held at | Holder |
+|---|---|---|
+| Voting keystore + password | `~/.votetorrent/release-keys/` (`voting-release.keystore`, `voting.env`, `CREDENTIALS.md`) | the machine that generated them on 2026-08-03 |
+| Authority keystore | `apps/VoteTorrentAuthority/android/app/release.keystore`, gitignored and untracked | same machine |
+| Authority password | password manager | the maintainer who rotated the key |
+
+Known fingerprint to verify a Voting handoff against — the received keystore must print
+this under `keytool -list -v`:
+
+```
+5C:48:5C:01:F4:2D:34:B8:A9:36:82:DF:F3:5B:99:93:A0:7B:D9:F0:73:4D:54:C8:63:30:8B:C8:28:C8:2B:4E
+```
+
+**Transferring keys:** send the `.keystore` files and passwords through a password
+manager's secure-share, an encrypted archive over a separate channel, or in person.
+Never email, Slack, or paste them into an issue, PR, or chat. Never commit a keystore —
+`apps/*/android/.gitignore` blocks `*.keystore`, and that guard should not be overridden
+with `git add -f`.
+
+If the handoff turns out to be impossible — the holder is unreachable, or the Voting key
+was genuinely throwaway — fall back to **B** and regenerate per §2, accepting that
+anyone who installed a fork APK must uninstall before they can take an upstream build.
+As of 2026-08-03 the only releases ever published from the fork are `voting-v0.1.0` and
+`authority-v0.1.0`, both first-ever CI test builds, so the installed base that would
+break is small.
 
 ---
 
 ## 1. Get the workflow into the repo
 
-The workflow does not exist upstream yet. It arrives via a PR from the fork
-(`inspirions/votetorrent`), which contains:
+**Done on `gotchoices/votetorrent` as of 2026-08-03** — landed on `develop` via #18 and
+promoted to `master` via #19. `.github/workflows/release-android.yml` is on the default
+branch and registers in the Actions tab as *"Release Android APKs"* (`state: active`),
+which also confirms Actions is enabled on the repository.
+
+The set that has to travel together, if you are doing this on another repository:
 
 ```
 .github/workflows/release-android.yml          the workflow
@@ -51,7 +90,7 @@ apps/VoteTorrentVoting/android/.gitignore       blocks committing a keystore
 doc/releases/RELEASE-ANDROID.md                         the operating runbook
 ```
 
-Merge that PR into your default branch **before** the tag push in step 5.
+Merge it into your default branch **before** the tag push in step 5.
 
 Two things to know about branch placement:
 
@@ -109,8 +148,8 @@ recovery from a lost release key.
 
 ## 3. Set the eight repository secrets
 
-All eight are **repository-level**: Settings → Secrets and variables → Actions → *New
-repository secret*. Or via `gh`:
+All eight are **repository-level**. Either Settings → Secrets and variables → Actions →
+*New repository secret* (that page needs admin), or via `gh`, which needs only write:
 
 ```bash
 REPO=gotchoices/votetorrent
@@ -165,15 +204,28 @@ rm -f /tmp/rt.keystore
 
 ---
 
-## 4. Confirm Actions is enabled
+## 4. Confirm Actions is enabled — the one admin-only step
 
 ```bash
 gh api repos/gotchoices/votetorrent/actions/permissions
 ```
 
-Expect `"enabled": true`. The workflow uses only first-party `actions/*` at major-version
-tags plus the runner's preinstalled `gh` CLI, so an `allowed_actions` policy restricted to
-GitHub-owned actions is sufficient — no third-party allowlisting needed.
+Expect `"enabled": true`. **This endpoint returns 403 below admin**, so a write-level
+maintainer cannot run it. There is a usable proxy that works at write level: once the
+workflow is on the default branch, check that it registered.
+
+```bash
+gh api repos/gotchoices/votetorrent/actions/workflows --jq '.workflows[] | {name, state}'
+```
+
+A workflow appearing with `"state": "active"` means Actions is enabled — a disabled
+repository registers nothing. On `gotchoices/votetorrent` this returned *"Release Android
+APKs"*, `active`, on 2026-08-03. What the proxy does **not** tell you is the
+`allowed_actions` policy or the workflow-token cap below; only an admin can read those.
+
+The workflow uses only first-party `actions/*` at major-version tags plus the runner's
+preinstalled `gh` CLI, so an `allowed_actions` policy restricted to GitHub-owned actions
+is sufficient — no third-party allowlisting needed.
 
 The workflow declares `permissions: contents: write`, which it needs to create releases and
 push the rolling tags. If your org sets the default `GITHUB_TOKEN` permissions to

--- a/doc/releases/RELEASE-ANDROID.md
+++ b/doc/releases/RELEASE-ANDROID.md
@@ -10,18 +10,24 @@ These two URLs are the deliverable: paste them into docs, QR codes, or chat.
 They never change, and each is updated independently of the other app's
 release cadence.
 
-* **Voting:** `https://github.com/inspirions/votetorrent/releases/download/latest-voting/votetorrent-voting-latest.apk`
-* **Authority:** `https://github.com/inspirions/votetorrent/releases/download/latest-authority/votetorrent-authority-latest.apk`
+* **Voting:** `https://github.com/gotchoices/votetorrent/releases/download/latest-voting/votetorrent-voting-latest.apk`
+* **Authority:** `https://github.com/gotchoices/votetorrent/releases/download/latest-authority/votetorrent-authority-latest.apk`
 
-Releases are cut from the **`inspirions/votetorrent`** fork, because that is where the
-signing secrets live (see section 3). The workflow itself is repo-agnostic — it builds
-its URLs from `${{ github.repository }}` — so if release duty ever moves upstream to
-`gotchoices/votetorrent`, only these documented links need updating, not the workflow.
+Releases are cut from **`gotchoices/votetorrent`**, which is the canonical release
+channel. The workflow itself is repo-agnostic — it builds its URLs from
+`${{ github.repository }}` — so a fork that sets its own signing secrets gets working
+permalinks against its own namespace with no edit to the workflow; only these documented
+links are repo-specific.
 
-> Standing this pipeline up on a different repository (e.g. upstream
-> `gotchoices/votetorrent`)? See **[doc/releases/RELEASE-ANDROID-UPSTREAM-SETUP.md](./RELEASE-ANDROID-UPSTREAM-SETUP.md)**
-> — an admin-facing checklist covering the signing-key decision, the eight secrets,
-> verification, and the two CI-only failure modes already fixed here.
+> The pipeline was originally built and validated on the `inspirions/votetorrent` fork,
+> where `voting-v0.1.0` and `authority-v0.1.0` were published on 2026-08-03. Those fork
+> permalinks still resolve, but they are **not** the ones to share — use the
+> `gotchoices` URLs above.
+
+> Standing this pipeline up on another repository? See
+> **[doc/releases/RELEASE-ANDROID-UPSTREAM-SETUP.md](./RELEASE-ANDROID-UPSTREAM-SETUP.md)**
+> — a checklist covering the signing-key decision, the eight secrets, verification, and
+> the two CI-only failure modes already fixed here.
 
 Why these URLs and not GitHub's built-in
 `https://github.com/<repo>/releases/latest/download/<asset>` shortcut: that
@@ -50,21 +56,21 @@ Tag prefix selects which app(s) build. `workflow_dispatch` overrides.
 | `v*` (e.g. `v1.2.3`) | Both |
 | Manual `workflow_dispatch` with `apps: both\|voting\|authority` | as chosen |
 
-The remote in this clone is named `gotchoices`, not `origin` — use that name
-when pushing tags:
+Push the tag to whichever remote points at `gotchoices/votetorrent` — `origin` in a
+direct clone, but often `upstream` in a clone of a fork. Substitute accordingly:
 
 ```bash
 # Voting only
 git tag voting-v0.1.0
-git push gotchoices voting-v0.1.0
+git push origin voting-v0.1.0
 
 # Authority only
 git tag authority-v0.0.4
-git push gotchoices authority-v0.0.4
+git push origin authority-v0.0.4
 
 # Both apps, coordinated release
 git tag v1.2.3
-git push gotchoices v1.2.3
+git push origin v1.2.3
 ```
 
 To build without cutting a version tag (e.g. to sanity-check signing or grab
@@ -75,29 +81,30 @@ still refreshes the rolling permalink for the chosen app(s), but it does
 
 ## 3. Repository secrets (required)
 
-All eight secrets below must be created as **repository-level** secrets:
-**Settings -> Secrets and variables -> Actions -> "New repository secret"**.
-Organization secrets are **not available** on this account, so nothing in the
-workflow may rely on them — every secret must be created individually on this
-repository.
+All eight secrets below must be created as **repository-level** secrets on
+`gotchoices/votetorrent`. Organization secrets are **not available** to this project, so
+nothing in the workflow may rely on them — every secret must be created individually on
+the repository.
 
-> **Fastest path:** run `~/.votetorrent/release-keys/set-github-secrets.sh`. It sets
-> all eight in one go, reading the Voting credentials from `voting.env`, prompting for
-> the Authority password (never stored on disk), and proving both passwords with
-> `keytool -list` before uploading anything.
+> **Which access you need.** Repository **write** is sufficient. The Actions secrets API
+> is gated on collaborator access, not admin, so `gh secret set --repo
+> gotchoices/votetorrent` works at write level — verified 2026-08-03 by setting and
+> deleting a throwaway secret with a non-admin account.
 >
-> **Which repo.** Set these on **`inspirions/votetorrent`** — the fork that cuts
-> releases. The `aarashrestha` account has `ADMIN` there, but only `READ` on upstream
-> `gotchoices/votetorrent`, where any `gh secret set` returns HTTP 403. The script
-> defaults to the upstream repo, so override it:
+> The **Settings -> Secrets and variables -> Actions** *UI* is a different matter: that
+> page lives under repository Settings and is admin-only. If you cannot open it, that
+> does not mean you cannot set the secrets — use `gh secret set`.
 >
-> ```bash
-> REPO=inspirions/votetorrent ~/.votetorrent/release-keys/set-github-secrets.sh
-> ```
->
-> (The script currently hardcodes `REPO=gotchoices/votetorrent` on line 13 — change that
-> line, or export `REPO` after making it overridable.) The table below is the manual
-> fallback.
+> One step in this setup genuinely does require admin: reading or changing the repo's
+> Actions policy (`GET /actions/permissions` returns 403 below admin). See
+> [RELEASE-ANDROID-UPSTREAM-SETUP.md](./RELEASE-ANDROID-UPSTREAM-SETUP.md) §4.
+
+> **Fastest path**, if you are the release manager holding the keys: run
+> `~/.votetorrent/release-keys/set-github-secrets.sh`. It sets all eight in one go,
+> reading the Voting credentials from `voting.env`, prompting for the Authority password
+> (never stored on disk), and proving both passwords with `keytool -list` before
+> uploading anything. It defaults to `REPO=gotchoices/votetorrent`, which is now the
+> correct target — no override needed. The table below is the manual fallback.
 
 | Secret | App | Source |
 |---|---|---|
@@ -132,19 +139,32 @@ Or set the secret directly with the `gh` CLI, without going through the
 clipboard:
 
 ```bash
-gh secret set AUTHORITY_KEYSTORE_BASE64 --repo inspirions/votetorrent \
+gh secret set AUTHORITY_KEYSTORE_BASE64 --repo gotchoices/votetorrent \
   < <(base64 -i apps/VoteTorrentAuthority/android/app/release.keystore)
 ```
 
 ## 4. The Voting keystore
 
-**Already generated (2026-08-03).** It lives outside the repo at
-`~/.votetorrent/release-keys/voting-release.keystore` (PKCS12, RSA-2048, alias
-`org.votetorrent.voting`, valid to 2053-12-19, cert SHA-256
-`5C:48:5C:01:F4:2D:34:B8:A9:36:82:DF:F3:5B:99:93:A0:7B:D9:F0:73:4D:54:C8:63:30:8B:C8:28:C8:2B:4E`).
-Its password is in `~/.votetorrent/release-keys/voting.env`; see
-`~/.votetorrent/release-keys/CREDENTIALS.md` for the full record. That directory is
+**Already generated (2026-08-03)** — PKCS12, RSA-2048, alias `org.votetorrent.voting`,
+valid to 2053-12-19, cert SHA-256
+`5C:48:5C:01:F4:2D:34:B8:A9:36:82:DF:F3:5B:99:93:A0:7B:D9:F0:73:4D:54:C8:63:30:8B:C8:28:C8:2B:4E`.
+
+Record that fingerprint: it is what a published Voting APK must match under
+`apksigner verify --print-certs`, and it is the only copy of the key's identity that
+exists outside the keystore itself.
+
+**The keystore is on the release manager's machine only**, outside the repo at
+`~/.votetorrent/release-keys/voting-release.keystore`, with its password in
+`voting.env` and the full record in `CREDENTIALS.md` alongside it. That directory is
 mode 700 and is **not** backed up automatically — back it up.
+
+It is deliberately not recoverable from anywhere else. GitHub Actions secrets are
+write-only: once `VOTING_KEYSTORE_BASE64` is set, no API call, workflow, or admin can
+read it back. A published APK carries only the public certificate, not the private key.
+So if you need these credentials on a second machine — to stand the pipeline up on
+another repository, for instance — they must be transferred from the holder through a
+password manager's secure-share, an encrypted archive, or in person. Never email, Slack,
+or paste them into an issue, PR, or chat.
 
 To build a signed release locally:
 


### PR DESCRIPTION
Makes `gotchoices/votetorrent` the documented release channel, now that the workflow is on `master` (#19) and registers in the Actions tab as *"Release Android APKs"* (`state: active`).

Docs only — no workflow, gradle, or source changes. The workflow needed no edit; it derives its URLs from `${{ github.repository }}`.

## ⚠️ Merge-gating note: these links 404 until the first upstream release is cut

Checked just now:

```
404  gotchoices/…/latest-voting/votetorrent-voting-latest.apk
404  gotchoices/…/latest-authority/votetorrent-authority-latest.apk
200  inspirions/…/latest-voting/votetorrent-voting-latest.apk
200  inspirions/…/latest-authority/votetorrent-authority-latest.apk
```

The new URLs are the correct *targets* — the rolling releases that back them don't exist upstream yet, and can't until the eight signing secrets are set. **Merging this before the first release ships two dead download links on the repo homepage.** Either hold this until a release is cut, or merge now accepting the gap. Flagging rather than deciding.

## What changed

**Permalinks → `gotchoices`** — `README.md` (the two APK links) and `doc/releases/RELEASE-ANDROID.md` §1.

**Secret target → `gotchoices`** — §3's "which repo" callout and the `gh secret set --repo` example. Tag-push examples now use `origin` instead of `gotchoices`, which was the *fork clone's* remote name for upstream and is wrong in a direct clone.

**Corrected the admin claim, in both docs.** They asserted that "setting Actions secrets is admin-only" and that `gh secret set` against upstream "returns HTTP 403". That is wrong: the Actions secrets API is gated on **collaborator** access, not admin. Verified by setting and immediately deleting a throwaway secret on this repo with a write-level, non-admin account. Only the Settings *UI* requires admin — a different thing, and easy to conflate.

This mattered practically: the old text told a write-level maintainer they were blocked when they weren't, and pointed them at the fork instead.

**Documented the one genuinely admin-gated step.** `GET /actions/permissions` returns 403 below admin. Added a write-level proxy — if a workflow appears in `actions/workflows` with `"state": "active"`, Actions is enabled, since a disabled repo registers nothing. Also stated what the proxy *can't* tell you: the `allowed_actions` policy and any org-wide cap on the workflow token, which still need an admin.

**Recorded the signing-key decision** (§0): **option A, reuse the fork's keys**, for both apps — upstream releases stay upgrade-compatible with APKs already distributed from the fork, and the Authority key rotated on 2026-07-30 stays the project's identity.

Option A carries a prerequisite the doc didn't spell out, so it now does: **the fork's secrets cannot be copied to upstream.** Actions secrets are write-only — once set, no API call, workflow, or admin can read them back, and a published APK carries only the public certificate, not the private key. The keystore files and passwords must be transferred from whoever holds them. §0 now names where each credential lives, and includes the known Voting cert SHA-256 so a handoff can be verified with `keytool -list -v` before it's trusted.

## Scope note

Three `inspirions` references remain, all historical attribution — where the pipeline was built and validated, and the working reference implementation. Those are factual and worth keeping.

The changes beyond pure URL-swapping (the admin correction, the key-handoff prerequisite) are the same statement class: *which repo do releases and secrets belong to, and who can do it*. Leaving them would have left the docs contradicting the repointing.
